### PR TITLE
SONARSCALA-57 Update orchestrator version to 5.5

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -30,7 +30,7 @@ dependencyResolutionManagement {
     def analyzerCommonsVersion = '2.16.0.3141'
     def pluginApiVersion = '10.10.0.2391'
     def sonarqubeVersion = '10.0.0.68432'
-    def orchestratorVersion = '5.1.0.2254'
+    def orchestratorVersion = '5.5.0.2535'
     def sonarlintVersion = '9.0.0.74282'
     // slf4j is provided by SQ, SC or SL, should be aligned with sonar-plugin-api
     def slf4jApiVersion = '1.7.30'


### PR DESCRIPTION
[SONARSCALA-57](https://sonarsource.atlassian.net/browse/SONARSCALA-57)

This is to avoid polluting telemetry data with integration tests.

[SONARSCALA-57]: https://sonarsource.atlassian.net/browse/SONARSCALA-57?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ