### PR TITLE
SONARSCALA-127 Do not run nightly builds on weekends

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
   workflow_dispatch:
   schedule:
-    - cron: "30 1 * * *" # Run daily at 1:30 AM UTC
+    - cron: "30 1 * * 1-5" # Run Mon-Fri at 1:30 AM UTC
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/unified-dogfooding.yml
+++ b/.github/workflows/unified-dogfooding.yml
@@ -1,7 +1,7 @@
 name: Unified Dogfooding scans
 on:
   schedule:
-    - cron: '15 3 * * *' # Run the workflow every day at 03:15 UTC
+    - cron: '15 3 * * 1-5' # Run Mon-Fri at 03:15 UTC
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Update cron schedules in GitHub Actions workflows to run Monday to Friday only (1-5), skipping weekends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)