### PR TITLE
SONARSCALA-129 Do not test PRs against DEV SQ

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
             sq_version: "LATEST_RELEASE"
         exclude:
           # DEV is tested only in nightly to reduce Repox usage
-          - item: { suite: "plugin", sq_version: "DEV", is_nightly: true }
+          - item: { suite: "plugin", sq_version: "DEV", is_nightly: false }
     name: "QA Tests [${{ matrix.item.suite }}] - SQ : ${{ matrix.item.sq_version }}"
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
             sq_version: "LATEST_RELEASE"
         exclude:
           # DEV is tested only in nightly to reduce Repox usage
-          - item: { suite: "plugin", sq_version: "DEV", is_nightly: false }
+          - item: { suite: "plugin", sq_version: "DEV", is_nightly: true }
     name: "QA Tests [${{ matrix.item.suite }}] - SQ : ${{ matrix.item.sq_version }}"
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,9 +59,18 @@ jobs:
         # Ruling tests check only that the results of analysis have not changed,
         # so one sonar.runtimeVersion is enough.
         item:
-          - { suite: "plugin", sq_version: "DEV", submodules: false}
-          - { suite: "plugin", sq_version: "LATEST_RELEASE", submodules: false}
-          - { suite: "ruling", sq_version: "LATEST_RELEASE" }
+          - suite: "plugin"
+            sq_version: "DEV"
+            submodules: false
+            is_nightly: ${{ github.event_name == 'schedule' }}
+          - suite: "plugin"
+            sq_version: "LATEST_RELEASE"
+            submodules: false
+          - suite: "ruling"
+            sq_version: "LATEST_RELEASE"
+        exclude:
+          # DEV is tested only in nightly to reduce Repox usage
+          - item: { suite: "plugin", sq_version: "DEV", submodules: false, is_nightly: false }
     name: "QA Tests [${{ matrix.item.suite }}] - SQ : ${{ matrix.item.sq_version }}"
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,16 +61,14 @@ jobs:
         item:
           - suite: "plugin"
             sq_version: "DEV"
-            submodules: false
             is_nightly: ${{ github.event_name == 'schedule' }}
           - suite: "plugin"
             sq_version: "LATEST_RELEASE"
-            submodules: false
           - suite: "ruling"
             sq_version: "LATEST_RELEASE"
         exclude:
           # DEV is tested only in nightly to reduce Repox usage
-          - item: { suite: "plugin", sq_version: "DEV", submodules: false, is_nightly: false }
+          - item: { suite: "plugin", sq_version: "DEV", is_nightly: false }
     name: "QA Tests [${{ matrix.item.suite }}] - SQ : ${{ matrix.item.sq_version }}"
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
- Skip QA tests against DEV SQ version on PR and push builds to reduce Repox usage
- DEV SQ tests now only run during nightly scheduled builds
- `submodules` are unused, so they are removed
- Mirrors the change from SonarSource/sonar-apex@fbb1cc5
- Tested: inverted the condition: https://github.com/SonarSource/sonar-scala/actions/runs/24389822501

🤖 Generated with [Claude Code](https://claude.com/claude-code)