### PR TITLE
SONARSCALA-150 Update jacoco to 0.8.14

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,7 @@ subprojects {
     }
 
     jacoco {
-        toolVersion = "0.8.7"
+        toolVersion = "0.8.14"
     }
 
     jacocoTestReport {


### PR DESCRIPTION
It fixes tons of jacoco stack traces related to Java version. Pluging QA log went from 50k lines to less than 4k.