### PR TITLE
SONARSCALA-153 Run mise in unified-dogfooding.yml

### DIFF
--- a/.github/workflows/unified-dogfooding.yml
+++ b/.github/workflows/unified-dogfooding.yml
@@ -13,6 +13,9 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          version: 2026.4.25
       - name: Initialize build-logic submodule
         run: git submodule update --init build-logic/common
       - uses: SonarSource/ci-github-actions/build-gradle@v1


### PR DESCRIPTION
Unified dogfooding was running on Java 17. After the update of sonarlint-core, we need Java 21. Adding mise step selects the correct Java version.

Tested: https://github.com/SonarSource/sonar-scala/actions/runs/26092804252