### PR TITLE
SONARSCALA-155 Bump log4j-api and log4j-core zinc constraint to 2.26.0

### DIFF
--- a/sonar-scala-plugin/build.gradle
+++ b/sonar-scala-plugin/build.gradle
@@ -73,10 +73,10 @@ dependencies {
     testRuntimeOnly testLibs.junit.platform.launcher
 
     constraints {
-        zinc('org.apache.logging.log4j:log4j-api:2.25.4') {
+        zinc('org.apache.logging.log4j:log4j-api:2.26.0') {
             because 'Address CVE-2021-44832 and subsequent vulnerabilities'
         }
-        zinc('org.apache.logging.log4j:log4j-core:2.25.4') {
+        zinc('org.apache.logging.log4j:log4j-core:2.26.0') {
             because 'Address CVE-2021-44832 and subsequent vulnerabilities'
         }
         zinc('com.google.protobuf:protobuf-java:4.34.1') {


### PR DESCRIPTION
----
## Summary by Gitar

- **Dependency updates:**
  - Bumped `log4j-api` and `log4j-core` constraints to version `2.26.0` in `sonar-scala-plugin/build.gradle`.

<sub>This will update automatically on new commits.</sub>